### PR TITLE
Restart all pumas and sidekiqs rather than specifying by application

### DIFF
--- a/lib/capistrano/tasks/services.rake
+++ b/lib/capistrano/tasks/services.rake
@@ -3,11 +3,11 @@ namespace :deploy do
     desc "Run #{command} on servers"
     task command do
       on roles(:web) do
-        execute :service, :puma, command, "app=#{current_path}"
+        sudo :service, 'puma-manager', command
       end
 
       on roles(:worker) do
-        execute :service, :sidekiq, command, "index=0 app=#{current_path}"
+        sudo :service, 'sidekiq-manager', command
       end
     end
 


### PR DESCRIPTION
We are changing the way we name our instances of puma and sidekiq; rather than changing it here every time we change it in the app, just restart the manager processes.
